### PR TITLE
build compatibility fix

### DIFF
--- a/um/um.vcxproj
+++ b/um/um.vcxproj
@@ -78,7 +78,6 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <SpectreMitigation>false</SpectreMitigation>
-    <VCToolsVersion>14.40.33807</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
## Problem
The project currently has a hardcoded `VCToolsVersion` that prevents compilation on systems without that exact Visual C++ tools version installed. This creates barriers for contributors and users.

## Background/ Fix
The `VCToolsVersion` element locks the project to a specific version of Visual C++ tools. When omitted, MSBuild automatically selects the appropriate version based on the `PlatformToolset`, making the project more portable across different Visual Studio installations.

Reference: [Microsoft Documentation on VCToolsVersion](https://docs.microsoft.com/en-us/cpp/build/reference/vcpp-directories-property-page)